### PR TITLE
Fix is_relative_to

### DIFF
--- a/src/androidemu/vfs/file_system.py
+++ b/src/androidemu/vfs/file_system.py
@@ -55,8 +55,15 @@ class VirtualFileSystem:
 
         file_path = self._root_path.joinpath(filename).resolve()
 
-        if not file_path.is_relative_to(self._root_path):
-            raise RuntimeError("Emulator tried to read outside vfs ('%s' not in '%s')." % (file_path, self._root_path))
+        # when system is macos, the pathlib.Path return was PosixPath, The PosixPath object does not have the is_relative_to method
+        if os.name == "posix":
+            try:
+                file_path.relative_to(self._root_path)
+            except:
+                raise RuntimeError("Emulator tried to read outside vfs ('%s' not in '%s')." % (file_path, self._root_path))
+        else:
+            if not file_path.is_relative_to(self._root_path):
+                raise RuntimeError("Emulator tried to read outside vfs ('%s' not in '%s')." % (file_path, self._root_path))
 
         return file_path
 

--- a/src/androidemu/vfs/file_system.py
+++ b/src/androidemu/vfs/file_system.py
@@ -55,11 +55,12 @@ class VirtualFileSystem:
 
         file_path = self._root_path.joinpath(filename).resolve()
 
-        # when system is macos, the pathlib.Path return was PosixPath, The PosixPath object does not have the is_relative_to method
-        if os.name == "posix":
+        # is_relative_to is new in version 3.9
+        if not hasattr(file_path, 'is_relative_to'):
             try:
                 file_path.relative_to(self._root_path)
             except:
+                # if file_path is not in the subpath of self._root_path, ValueError is raised
                 raise RuntimeError("Emulator tried to read outside vfs ('%s' not in '%s')." % (file_path, self._root_path))
         else:
             if not file_path.is_relative_to(self._root_path):


### PR DESCRIPTION
[`is_relative_to`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.is_relative_to) is new in version 3.9

So if `is_relative_to` is not available, will use [`relative_to`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to). It will raise ValueError when file_path is not in the subpath of self._root_path.