### PR TITLE
Github action: fix bug and run example*.py for test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,23 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools
         pip install tox tox-gh-actions
-    - name: Test
+    - name: Install to system
+      run: |
+        python setup.py install
+    - name: Run tox for Test
       run: |
         tox
+    - name: Run example*.py for test
+      shell: bash
+      run: |
+        cd examples
+        for file in $(ls example*.py); do
+            echo "::group::Run $file"
+            python3 "$file"
+            echo "::endgroup::"
+        done
 
   build:
     needs: [test]


### PR DESCRIPTION
- Use correct version when setup python
- Use `example*.py` for test
    because it seem that using `tox` for test didn't work now. 