### PR TITLE
Fix: Support loading SO files when relocation and symbol table sections are missing

### DIFF
--- a/src/androidemu/internal/modules.py
+++ b/src/androidemu/internal/modules.py
@@ -1,8 +1,12 @@
 import logging
 
+import elftools
+import elftools.elf
 from elftools.elf.elffile import ELFFile
 from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import SymbolTableSection
+from elftools.elf.sections import StringTableSection
+import elftools.elf.sections
 from unicorn import UC_PROT_ALL
 
 from androidemu.internal import get_segment_protection, arm
@@ -43,6 +47,12 @@ class Modules:
             if module.base == addr:
                 return module
         return None
+
+    def find_section_index(self, elf, addr):
+        for idx, section in enumerate(elf.iter_sections()):
+            if section.header['sh_addr'] <= addr < (section.header['sh_addr'] + section.header['sh_size']):
+                return idx
+        return 0
 
     def load_module(self, filename):
         logger.debug("Loading module '%s'." % filename)
@@ -101,6 +111,122 @@ class Modules:
             dynsym = elf.get_section_by_name(".dynsym")
             dynstr = elf.get_section_by_name(".dynstr")
 
+            # Find rel section if not found.
+            if rel_section is None or dynsym is None or dynstr is None:
+                rel_info = {
+                    'rel': {'addr': None, 'size': None, 'entsize': None, 'count': None},
+                    'rela': {'addr': None, 'size': None, 'entsize': None, 'count': None},
+                    'sym': None,
+                    'type': None
+                }
+                
+                sym_info = {
+                    'dynsym': {'addr': None, 'size': None, 'entsize': None},
+                    'dynstr': {'addr': None, 'size': None}
+                }
+
+                # get information from dynamic segment
+                for segment in elf.iter_segments():
+                    if segment.header.p_type == 'PT_DYNAMIC':
+                        for tag in segment.iter_tags():
+                            # find relocation table
+                            if tag.entry.d_tag == 'DT_REL':
+                                rel_info['rel']['addr'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELSZ':
+                                rel_info['rel']['size'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELENT':
+                                rel_info['rel']['entsize'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELCOUNT':
+                                rel_info['rel']['count'] = tag.entry.d_val
+                            
+                            # find relocation table with addend
+                            elif tag.entry.d_tag == 'DT_RELA':
+                                rel_info['rela']['addr'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELASZ':
+                                rel_info['rela']['size'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELAENT':
+                                rel_info['rela']['entsize'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_RELACOUNT':
+                                rel_info['rela']['count'] = tag.entry.d_val
+                            
+                            # find symbol table
+                            elif tag.entry.d_tag == 'DT_SYMTAB':
+                                rel_info['sym'] = self.find_section_index(elf, tag.entry.d_val)
+                                sym_info['dynsym']['addr'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_STRTAB':
+                                sym_info['dynstr']['addr'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_STRSZ':
+                                sym_info['dynstr']['size'] = tag.entry.d_val
+                            elif tag.entry.d_tag == 'DT_SYMENT':
+                                sym_info['dynsym']['entsize'] = tag.entry.d_val
+
+                if rel_section is None:
+                    if rel_info['rel']['addr'] and rel_info['rel']['size']:
+                        rel_info['type'] = 'REL'
+                        active_rel = rel_info['rel']
+                        has_reloc_info = True
+                    elif rel_info['rela']['addr'] and rel_info['rela']['size']:
+                        rel_info['type'] = 'RELA'
+                        active_rel = rel_info['rela']
+                        has_reloc_info = True
+                    else:
+                        has_reloc_info = False
+
+                    if has_reloc_info and active_rel['addr'] and active_rel['size'] and active_rel['entsize']:
+                        is_rela = rel_info['type'] == 'RELA'
+                        fake_rel_header = {
+                            'sh_name': 0, # we don't know the name
+                            'sh_type': 'SHT_RELA' if is_rela else 'SHT_REL',
+                            'sh_flags': 2,
+                            'sh_addr': active_rel['addr'],
+                            'sh_offset': active_rel['addr'],
+                            'sh_size': active_rel['size'],
+                            'sh_link': rel_info['sym'], # link to dynsym
+                            'sh_info': 0,
+                            'sh_addralign': 8 if elf.elfclass == 64 else 4,
+                            'sh_entsize': active_rel['entsize']
+                        }
+                        rel_section = RelocationSection(fake_rel_header, 
+                                                    '.rela.dyn' if is_rela else '.rel.dyn',
+                                                    elf)
+
+                # create dynsym and dynstr if not found
+                if dynstr is None or dynsym is None:
+                    # calculate dynsym size
+                    if sym_info['dynsym']['addr'] and sym_info['dynstr']['addr']:
+                        sym_info['dynsym']['size'] = sym_info['dynstr']['addr'] - sym_info['dynsym']['addr']
+
+                    if dynstr is None and sym_info['dynstr']['addr'] and sym_info['dynstr']['size']:
+                        fake_str_header = {
+                            'sh_name': 0,
+                            'sh_type': 'SHT_STRTAB',
+                            'sh_flags': 2,
+                            'sh_addr': sym_info['dynstr']['addr'],
+                            'sh_offset': sym_info['dynstr']['addr'],
+                            'sh_size': sym_info['dynstr']['size'],
+                            'sh_link': 0,
+                            'sh_info': 0,
+                            'sh_addralign': 1,
+                            'sh_entsize': 0
+                        }
+                        dynstr = StringTableSection(fake_str_header, '.dynstr', elf)
+
+                    if dynsym is None and dynstr is not None and \
+                    sym_info['dynsym']['addr'] and sym_info['dynsym']['size']:
+                        fake_sym_header = {
+                            'sh_name': 0,
+                            'sh_type': 'SHT_DYNSYM',
+                            'sh_flags': 2,
+                            'sh_addr': sym_info['dynsym']['addr'],
+                            'sh_offset': sym_info['dynsym']['addr'],
+                            'sh_size': sym_info['dynsym']['size'],
+                            'sh_link': self.find_section_index(elf, sym_info['dynstr']['addr']), # link to dynstr
+                            'sh_info': 0, # we don't know the index of the first non-local symbol
+                            'sh_addralign': 8 if elf.elfclass == 64 else 4,
+                            'sh_entsize': sym_info['dynsym']['entsize']
+                        }
+                        dynsym = SymbolTableSection(fake_sym_header, '.dynsym', elf, dynstr)
+
             # Find init array.
             init_array_size = 0
             init_array_offset = 0
@@ -141,23 +267,24 @@ class Modules:
             # Resolve all symbols.
             symbols_resolved = dict()
 
-            for section in elf.iter_sections():
-                if not isinstance(section, SymbolTableSection):
-                    continue
-
-                itersymbols = section.iter_symbols()
+            # for section in elf.iter_sections():
+            #     if not isinstance(section, SymbolTableSection):
+            #         continue
+            if dynsym:
+                itersymbols = dynsym.iter_symbols()
                 next(itersymbols)  # Skip first symbol which is always NULL.
                 for symbol in itersymbols:
                     symbol_address = self._elf_get_symval(elf, load_base, symbol)
                     if symbol_address is not None:
+                        # TODO: Maybe we need to do something with uname symbols？
                         symbols_resolved[symbol.name] = SymbolResolved(symbol_address, symbol)
 
             # Relocate.
-            for section in elf.iter_sections():
-                if not isinstance(section, RelocationSection):
-                    continue
-
-                for rel in section.iter_relocations():
+            # for section in elf.iter_sections():
+            #     if not isinstance(section, RelocationSection): 
+            #         continue
+            if rel_section:
+                for rel in rel_section.iter_relocations():
                     sym = dynsym.get_symbol(rel['r_info_sym'])
                     sym_value = sym['st_value']
 


### PR DESCRIPTION
Previously:
- Failed to load SO files without relocation sections
- Failed to load SO files without symbol table sections

Changes:
- Parse and create fake relocation sections from PT_DYNAMIC 
- Parse and create fake symbol table sections from PT_DYNAMIC
- Continue loading even when sections are missing

Makes so loading more robust by recovering section information from program headers when section headers are stripped.