### PR TITLE
Bump Unicorn lib to 2.1.2 + python 3.12/3.13 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,16 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
-        # macos-latest is ARM-based and python 3.7 is not present
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         exclude:
+          # macos-latest is ARM-based and python 3.7 is not present
           - platform: macos-latest
+            python-version: 3.7
+          # python 3.7 is not present on ubuntu 24.04
+          - platform: ubuntu-latest
+            python-version: 3.7
+        include:
+          - platform: ubuntu-22.04
             python-version: 3.7
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "androidemu"
 version = "0.0.3"
-requires-python = ">=3.7, <3.12"
+requires-python = ">=3.7"
 authors = [
     { name = "AeonLucid", email = "aeonlucid@gmail.com" },
 ]
@@ -22,9 +22,11 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 dependencies = [
-    "unicorn==2.1.0",
+    "unicorn==2.1.2",
     "pyelftools==0.31",
     "hexdump==3.3",
     "keystone-engine==0.9.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py{37,38,39,310,311}-{linux,macos,windows}
+envlist = py{37,38,39,310,311,312,313}-{linux,macos,windows}
 
 [gh-actions]
 python =
@@ -8,6 +8,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
- Bump unicorn lib to 2.1.2
- Expand pytest suite with python 3.12 and 3.13
- Expand workflow matrix with python 3.12 and 3.13